### PR TITLE
refactor: rename `with_error_fn` into `when`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@
 //! async fn main() -> Result<()> {
 //!     let content = fetch
 //!         .retry(ExponentialBackoff::default())
-//!         .with_error_fn(|e| e.to_string() == "retryable").await?;
+//!         .when(|e| e.to_string() == "retryable").await?;
 //!
 //!     println!("fetch succeeded: {}", content);
 //!     Ok(())


### PR DESCRIPTION
Rename `with_error_fn` into `when`.

Closes #11 