### PR TITLE
Change method parameter when to Result type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@
 //! async fn main() -> Result<()> {
 //!     let content = fetch
 //!         .retry(&ExponentialBuilder::default())
-//!         .when(|e| e.to_string() == "retryable")
+//!         .when(|r| matches!(r,Err(e) if e.to_string() == "retryable"))
 //!         .await?;
 //!
 //!     println!("fetch succeeded: {}", content);


### PR DESCRIPTION
## Purpose
The output of some API is `Result<Result<T,E2>,E1>` or `Result<Option<T>,E>` , error checking in the `when` method is not enough

## Checklist
- [x] Self-review has been completed
- [x] Changes are complete and ready for review
- [x] Changes are covered by existing or new tests
