### PR TITLE
Remove duplicate example, point to examples on docs index page

### DIFF
--- a/examples/async.rs
+++ b/examples/async.rs
@@ -2,6 +2,8 @@ use anyhow::Result;
 use backon::ExponentialBuilder;
 use backon::Retryable;
 
+// For more examples, please see: https://docs.rs/backon/#examples
+
 async fn fetch() -> Result<String> {
     let response = reqwest::get("https://httpbingo.org/unstable?failure_rate=0.7").await?;
     if !response.status().is_success() {

--- a/examples/blocking.rs
+++ b/examples/blocking.rs
@@ -2,6 +2,8 @@ use anyhow::Result;
 use backon::BlockingRetryable;
 use backon::ExponentialBuilder;
 
+// For more examples, please see: https://docs.rs/backon/#examples
+
 fn fetch() -> Result<String> {
     Ok("hello, world!".to_string())
 }

--- a/examples/closure.rs
+++ b/examples/closure.rs
@@ -2,6 +2,8 @@ use anyhow::Result;
 use backon::BlockingRetryable;
 use backon::ExponentialBuilder;
 
+// For more examples, please see: https://docs.rs/backon/#examples
+
 fn main() -> Result<()> {
     let var = 42;
     // `f` can use input variables

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -38,28 +38,10 @@ use crate::Backoff;
 /// }
 /// ```
 ///
-/// # Example
+/// # Examples
 ///
-/// ```no_run
-/// use anyhow::Result;
-/// use backon::ExponentialBuilder;
-/// use backon::Retryable;
+/// For more examples, please see: [https://docs.rs/backon/#examples](https://docs.rs/backon/#examples)
 ///
-/// async fn fetch() -> Result<String> {
-///     Ok(reqwest::get("https://www.rust-lang.org")
-///         .await?
-///         .text()
-///         .await?)
-/// }
-///
-/// #[tokio::main(flavor = "current_thread")]
-/// async fn main() -> Result<()> {
-///     let content = fetch.retry(&ExponentialBuilder::default()).await?;
-///     println!("fetch succeeded: {}", content);
-///
-///     Ok(())
-/// }
-/// ```
 pub trait Retryable<
     B: BackoffBuilder,
     T,


### PR DESCRIPTION
This PR is based on my own developer experience, of not knowing how to make backon work with an async call that takes variable arguments. 

To avoid having duplicate examples is various places, we rather point to the documentation index page, where the main collection of examples seems to be placed. This way hopefully developers can find the examples they need to find, more easily.