### PR TITLE
chore: Allow build blocking in wasm32

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-      - run: wasm-pack test --node --all-features
+      - run: wasm-pack test --node --all-features -- --skip blocking
         env:
           RUST_LOG: DEBUG
           RUST_BACKTRACE: full

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,18 +114,12 @@ pub use sleep::Sleeper;
 #[cfg(all(not(target_arch = "wasm32"), feature = "tokio-sleep"))]
 pub use sleep::TokioSleeper;
 
-#[cfg(not(target_arch = "wasm32"))]
 mod blocking_retry;
-#[cfg(not(target_arch = "wasm32"))]
 pub use blocking_retry::BlockingRetry;
-#[cfg(not(target_arch = "wasm32"))]
 pub use blocking_retry::BlockingRetryable;
 
-#[cfg(not(target_arch = "wasm32"))]
 mod blocking_retry_with_context;
-#[cfg(not(target_arch = "wasm32"))]
 pub use blocking_retry_with_context::BlockingRetryWithContext;
-#[cfg(not(target_arch = "wasm32"))]
 pub use blocking_retry_with_context::BlockingRetryableWithContext;
 
 #[cfg(docsrs)]


### PR DESCRIPTION
blocking in wasm doesn't make sense but allow build them makes backon easier to use. Let's add them back.