### PR TITLE
refactor: Enable default features to avoid unexpected panic

### DIFF
--- a/backon/Cargo.toml
+++ b/backon/Cargo.toml
@@ -20,11 +20,12 @@ targets = [
 ]
 
 [features]
+default = ["tokio-sleep", "gloo-timers-sleep"]
 gloo-timers-sleep = ["dep:gloo-timers", "gloo-timers?/futures"]
 tokio-sleep = ["dep:tokio", "tokio?/time"]
 
 [dependencies]
-fastrand = "2.0.0"
+fastrand = "2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", optional = true }

--- a/backon/src/lib.rs
+++ b/backon/src/lib.rs
@@ -33,12 +33,14 @@
 //!
 //! Retry in BackON requires an implementation for sleeping. BackON will accept a [`Sleeper`] to pause for a specified duration.
 //!
-//! BackON offers the following features for users to choose from:
+//! BackON employs the following default sleep implementations:
 //!
-//! - `tokio-sleep`: Use [`TokioSleeper`] within a Tokio context.
-//! - `gloo-timers-sleep`: Use [`GlooTimersSleep`] to pause in a wasm32 environment.
+//! - `tokio-sleep`: Utilizes [`TokioSleeper`] within a Tokio context in non-wasm32 environments.
+//! - `gloo-timers-sleep`: Utilizes [`GlooTimersSleep`] to pause in wasm32 environments.
 //!
-//! Users MUST provide a custom implementation if they prefer not to use the default options.
+//! Users CAN provide a custom implementation if they prefer not to use the default options.
+//!
+//! If neither feature is enabled nor a custom implementation is provided, BackON will fallback to an empty sleeper. This will cause a panic in the `debug` profile and do nothing in the `release` profile.
 //!
 //! # Retry
 //!
@@ -123,6 +125,7 @@ mod sleep;
 pub use sleep::DefaultSleeper;
 #[cfg(all(target_arch = "wasm32", feature = "gloo-timers-sleep"))]
 pub use sleep::GlooTimersSleep;
+pub(crate) use sleep::NoopSleeper;
 pub use sleep::Sleeper;
 #[cfg(all(not(target_arch = "wasm32"), feature = "tokio-sleep"))]
 pub use sleep::TokioSleeper;

--- a/backon/src/retry.rs
+++ b/backon/src/retry.rs
@@ -263,6 +263,11 @@ where
     type Output = Result<T, E>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        #[cfg(debug_assertions)]
+        if std::any::TypeId::of::<SF>() == std::any::TypeId::of::<crate::NoopSleeper>() {
+            panic!("BackON: No sleeper has been configured. Please enable the features or provide a custom implementation.")
+        }
+
         // Safety: This is safe because we don't move the `Retry` struct itself,
         // only its internal state.
         //

--- a/backon/src/retry_with_context.rs
+++ b/backon/src/retry_with_context.rs
@@ -302,6 +302,11 @@ where
     type Output = (Ctx, Result<T, E>);
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        #[cfg(debug_assertions)]
+        if std::any::TypeId::of::<SF>() == std::any::TypeId::of::<crate::NoopSleeper>() {
+            panic!("BackON: No sleeper has been configured. Please enable the features or provide a custom implementation.")
+        }
+
         // Safety: This is safe because we don't move the `Retry` struct itself,
         // only its internal state.
         //


### PR DESCRIPTION
Most backon users are accustomed to having a default sleep implementation, making it easy for them to upgrade to new versions like `0.5` or `1.0` without the feature enabled. For example: https://github.com/Xuanwo/backon/issues/128

Let's add default features to simplify their experience. Users who want custom implementations will not be affected.