### PR TITLE
fix: compile to fail when using DefaultSleeper with no features enabled

### DIFF
--- a/backon/src/lib.rs
+++ b/backon/src/lib.rs
@@ -125,7 +125,7 @@ mod sleep;
 pub use sleep::DefaultSleeper;
 #[cfg(all(target_arch = "wasm32", feature = "gloo-timers-sleep"))]
 pub use sleep::GlooTimersSleep;
-pub(crate) use sleep::NoopSleeper;
+pub(crate) use sleep::PleaseEnableAFeatureForSleeper;
 pub use sleep::Sleeper;
 #[cfg(all(not(target_arch = "wasm32"), feature = "tokio-sleep"))]
 pub use sleep::TokioSleeper;

--- a/backon/src/lib.rs
+++ b/backon/src/lib.rs
@@ -125,7 +125,6 @@ mod sleep;
 pub use sleep::DefaultSleeper;
 #[cfg(all(target_arch = "wasm32", feature = "gloo-timers-sleep"))]
 pub use sleep::GlooTimersSleep;
-pub(crate) use sleep::PleaseEnableAFeatureForSleeper;
 pub use sleep::Sleeper;
 #[cfg(all(not(target_arch = "wasm32"), feature = "tokio-sleep"))]
 pub use sleep::TokioSleeper;

--- a/backon/src/retry.rs
+++ b/backon/src/retry.rs
@@ -264,13 +264,6 @@ where
     type Output = Result<T, E>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        #[cfg(debug_assertions)]
-        if std::any::TypeId::of::<SF>()
-            == std::any::TypeId::of::<crate::PleaseEnableAFeatureForSleeper>()
-        {
-            panic!("BackON: No sleeper has been configured. Please enable the features or provide a custom implementation.")
-        }
-
         // Safety: This is safe because we don't move the `Retry` struct itself,
         // only its internal state.
         //

--- a/backon/src/retry_with_context.rs
+++ b/backon/src/retry_with_context.rs
@@ -303,13 +303,6 @@ where
     type Output = (Ctx, Result<T, E>);
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        #[cfg(debug_assertions)]
-        if std::any::TypeId::of::<SF>()
-            == std::any::TypeId::of::<crate::PleaseEnableAFeatureForSleeper>()
-        {
-            panic!("BackON: No sleeper has been configured. Please enable the features or provide a custom implementation.")
-        }
-
         // Safety: This is safe because we don't move the `Retry` struct itself,
         // only its internal state.
         //


### PR DESCRIPTION
- Makes compilation to fail when using `DefaultSleeper` with no features enabled.
  - Should not panic as it is a valid `Sleeper` is guaranteed at compile time.
- docs to instruct users to enable a feature or provide custom `Sleeper`.

Close https://github.com/Xuanwo/backon/issues/128