### PR TITLE
docs: mention sleep() in blocking retry examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ fn main() -> Result<()> {
     let content = fetch
         // Retry with exponential backoff
         .retry(ExponentialBuilder::default())
+        // Sleep implementation, required if no feature has been enabled
+        .sleep(std::thread::sleep)
         // When to retry
         .when(|e| e.to_string() == "EOF")
         // Notify when retrying

--- a/backon/src/lib.rs
+++ b/backon/src/lib.rs
@@ -94,6 +94,8 @@
 //!     let content = fetch
 //!         // Retry with exponential backoff
 //!         .retry(ExponentialBuilder::default())
+//!         // Sleep implementation, default to std::thread::sleep if `std-blocking-sleep` has been enabled.
+//!         .sleep(std::thread::sleep)
 //!         // When to retry
 //!         .when(|e| e.to_string() == "EOF")
 //!         // Notify when retrying


### PR DESCRIPTION
### What does this PR do

Based on the [discussion](https://github.com/Xuanwo/backon/pull/131#discussion_r1743700760), mention `sleep()` in the blocking retry examples.

Added to examples in both `README.md` and `lib.rs`.