### PR TITLE
feat: add Sleeper based on `futures-timer`

### DIFF
--- a/backon/Cargo.toml
+++ b/backon/Cargo.toml
@@ -20,7 +20,7 @@ targets = [
 ]
 
 [features]
-default = ["std", "std-blocking-sleep", "tokio-sleep", "gloo-timers-sleep", "futures-timer-sleep"]
+default = ["std", "std-blocking-sleep", "tokio-sleep", "gloo-timers-sleep"]
 std = ["fastrand/std"]
 std-blocking-sleep = []
 gloo-timers-sleep = ["gloo-timers/futures"]

--- a/backon/Cargo.toml
+++ b/backon/Cargo.toml
@@ -20,20 +20,23 @@ targets = [
 ]
 
 [features]
-default = ["std", "std-blocking-sleep", "tokio-sleep", "gloo-timers-sleep"]
+default = ["std", "std-blocking-sleep", "tokio-sleep", "gloo-timers-sleep", "futures-timer-sleep"]
 std = ["fastrand/std"]
 std-blocking-sleep = []
 gloo-timers-sleep = ["gloo-timers/futures"]
 tokio-sleep = ["tokio/time"]
+futures-timer-sleep = ["futures-timer"]
 
 [dependencies]
 fastrand = { version = "2", default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", optional = true }
+futures-timer = { version = "3.0.3", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 gloo-timers = { version = "0.3", optional = true }
+futures-timer = { version = "3.0.3", optional = true, features = ["gloo-timers"]}
 
 [dev-dependencies]
 anyhow = "1"

--- a/backon/src/lib.rs
+++ b/backon/src/lib.rs
@@ -41,11 +41,12 @@
 //! environments, they are gated under their own features, which are enabled
 //! by default:
 //!
-//! |      `Sleeper`      | feature            | Environment |  Asynchronous |
-//! |---------------------|--------------------|-------------|---------------|
-//! | [`TokioSleeper`]    | tokio-sleep        | non-wasm32  |  Yes          |
-//! | [`GlooTimersSleep`] | gloo-timers-sleep  |   wasm32    |  Yes          |
-//! | [`StdSleeper`]      | std-blocking-sleep |    std      |  No           |
+//! |      `Sleeper`       | feature            | Environment |  Asynchronous |
+//! |----------------------|--------------------|-------------|---------------|
+//! | [`TokioSleeper`]     | tokio-sleep        | non-wasm32  |  Yes          |
+//! | [`GlooTimersSleep`]  | gloo-timers-sleep  |   wasm32    |  Yes          |
+//! | [`FutureTimerSleep`] | future-timer-sleep |   both      |  Yes          |
+//! | [`StdSleeper`]       | std-blocking-sleep |    std      |  No           |
 //!
 //! ## Custom Sleeper
 //!

--- a/backon/src/sleep.rs
+++ b/backon/src/sleep.rs
@@ -36,11 +36,7 @@ impl<F: Fn(Duration) -> Fut + 'static, Fut: Future<Output = ()>> Sleeper for F {
 /// The default implementation of `Sleeper` when no features are enabled.
 ///
 /// It will fail to compile if a containing [`Retry`][crate::Retry] is `.await`ed without calling [`Retry::sleep`][crate::Retry::sleep] to provide a valid sleeper.
-#[cfg(all(
-    not(feature = "tokio-sleep"),
-    not(feature = "gloo-timers-sleep"),
-    not(feature = "futures-timer-sleep")
-))]
+#[cfg(all(not(feature = "tokio-sleep"), not(feature = "gloo-timers-sleep"),))]
 pub type DefaultSleeper = PleaseEnableAFeatureOrProvideACustomSleeper;
 /// The default implementation of `Sleeper` while feature `tokio-sleep` enabled.
 ///
@@ -52,15 +48,6 @@ pub type DefaultSleeper = TokioSleeper;
 /// It uses `gloo_timers::sleep::sleep`.
 #[cfg(all(target_arch = "wasm32", feature = "gloo-timers-sleep"))]
 pub type DefaultSleeper = GlooTimersSleep;
-/// The default implementation of `Sleeper` while only the feature `futures-timer-sleep` is enabled.
-///
-/// It uses `futures_timer::Delay`.
-#[cfg(all(
-    not(feature = "tokio-sleep"),
-    not(feature = "gloo-timers-sleep"),
-    feature = "futures-timer-sleep"
-))]
-pub type DefaultSleeper = FuturesTimerSleep;
 
 /// A placeholder type that does not implement [`Sleeper`] and will therefore fail to compile if used as one.
 ///


### PR DESCRIPTION
## What

This PR adds the new `FuturesTimerSleep` implementation of a `Sleeper` which is based on the https://docs.rs/futures-timer/latest/futures_timer/ crate.

This timer is runtime agnostic and also works in WASM environments and is gated via `futures-timer-sleep` feature (enabled per default).

Closes https://github.com/Xuanwo/backon/issues/153