### PR TITLE
chore: Remove unnecessary optional feature selectors

### DIFF
--- a/backon/Cargo.toml
+++ b/backon/Cargo.toml
@@ -22,8 +22,8 @@ targets = [
 [features]
 default = ["std-blocking-sleep", "tokio-sleep", "gloo-timers-sleep"]
 std-blocking-sleep = []
-gloo-timers-sleep = ["dep:gloo-timers", "gloo-timers?/futures"]
-tokio-sleep = ["dep:tokio", "tokio?/time"]
+gloo-timers-sleep = ["dep:gloo-timers", "gloo-timers/futures"]
+tokio-sleep = ["dep:tokio", "tokio/time"]
 
 [dependencies]
 fastrand = "2"

--- a/backon/Cargo.toml
+++ b/backon/Cargo.toml
@@ -22,8 +22,8 @@ targets = [
 [features]
 default = ["std-blocking-sleep", "tokio-sleep", "gloo-timers-sleep"]
 std-blocking-sleep = []
-gloo-timers-sleep = ["dep:gloo-timers", "gloo-timers/futures"]
-tokio-sleep = ["dep:tokio", "tokio/time"]
+gloo-timers-sleep = ["gloo-timers/futures"]
+tokio-sleep = ["tokio/time"]
 
 [dependencies]
 fastrand = "2"


### PR DESCRIPTION
Sorry for nitpicking, I was wondering what the question marks mean in the feature deps and after learning about their meaning it occured to me that they are actually not necessary here, since the tokio respectively gloo-timers crate is added as a dependency in the same feature. Hope I understood it correctly, happy to learn more about this syntax.