### PR TITLE
Add embassy-time sleeper

### DIFF
--- a/backon/Cargo.toml
+++ b/backon/Cargo.toml
@@ -20,13 +20,16 @@ targets = [
 ]
 
 [features]
-default = ["std-blocking-sleep", "tokio-sleep", "gloo-timers-sleep"]
+default = ["std-blocking-sleep", "tokio-sleep", "gloo-timers-sleep", "std"]
 std-blocking-sleep = []
-gloo-timers-sleep = ["dep:gloo-timers", "gloo-timers?/futures"]
-tokio-sleep = ["dep:tokio", "tokio?/time"]
+gloo-timers-sleep = ["gloo-timers/futures"]
+tokio-sleep = ["tokio/time"]
+embassy-sleep = ["embassy-time"]
+std = ["fastrand/std"]
 
 [dependencies]
-fastrand = "2"
+fastrand = { version = "2", default-features = false }
+embassy-time = { version = "0.3", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", optional = true }

--- a/backon/src/backoff/constant.rs
+++ b/backon/src/backoff/constant.rs
@@ -120,7 +120,7 @@ impl Iterator for ConstantBackoff {
 
     fn next(&mut self) -> Option<Self::Item> {
         let delay = || match self.jitter {
-            true => self.delay + self.delay.mul_f32(fastrand::f32()),
+            true => self.delay + self.delay.mul_f32(super::f32()),
             false => self.delay,
         };
         match self.max_times {

--- a/backon/src/backoff/exponential.rs
+++ b/backon/src/backoff/exponential.rs
@@ -194,7 +194,7 @@ impl Iterator for ExponentialBackoff {
         };
         // If jitter is enabled, add random jitter based on min delay.
         if self.jitter {
-            tmp_cur = tmp_cur.saturating_add(self.min_delay.mul_f32(fastrand::f32()));
+            tmp_cur = tmp_cur.saturating_add(self.min_delay.mul_f32(super::f32()));
         }
         Some(tmp_cur)
     }

--- a/backon/src/backoff/fibonacci.rs
+++ b/backon/src/backoff/fibonacci.rs
@@ -162,7 +162,7 @@ impl Iterator for FibonacciBackoff {
 
                 // If jitter is enabled, add random jitter based on min delay.
                 if self.jitter {
-                    next += self.min_delay.mul_f32(fastrand::f32());
+                    next += self.min_delay.mul_f32(super::f32());
                 }
 
                 Some(next)
@@ -181,7 +181,7 @@ impl Iterator for FibonacciBackoff {
 
                 // If jitter is enabled, add random jitter based on min delay.
                 if self.jitter {
-                    next += self.min_delay.mul_f32(fastrand::f32());
+                    next += self.min_delay.mul_f32(super::f32());
                 }
 
                 Some(next)

--- a/backon/src/backoff/mod.rs
+++ b/backon/src/backoff/mod.rs
@@ -12,3 +12,18 @@ pub use fibonacci::FibonacciBuilder;
 mod exponential;
 pub use exponential::ExponentialBackoff;
 pub use exponential::ExponentialBuilder;
+
+#[cfg(feature = "std")]
+fn f32() -> f32 {
+    fastrand::f32()
+}
+
+#[cfg(all(not(feature = "std"), feature = "embassy-time"))]
+fn f32() -> f32 {
+    fastrand::Rng::with_seed(embassy_time::Instant::now().as_micros()).f32()
+}
+
+#[cfg(all(not(feature = "std"), not(feature = "embassy-time")))]
+fn f32() -> f32 {
+    fastrand::Rng::with_seed(0x2fdb0020ffc7722b).f32()
+}

--- a/backon/src/lib.rs
+++ b/backon/src/lib.rs
@@ -45,7 +45,8 @@
 //! |---------------------|--------------------|-------------|---------------|
 //! | [`TokioSleeper`]    | tokio-sleep        | non-wasm32  |  Yes          |
 //! | [`GlooTimersSleep`] | gloo-timers-sleep  |   wasm32    |  Yes          |
-//! | [`StdSleeper`]      | std-blocking-sleep |    all      |  No           |
+//! | [`EmbassySleep`]    | embassy-sleep      |   no_std    |  Yes          |
+//! | [`StdSleeper`]      | std-blocking-sleep |    std      |  No           |
 //!
 //! ## Custom Sleeper
 //!
@@ -173,6 +174,8 @@ pub use sleep::GlooTimersSleep;
 pub use sleep::Sleeper;
 #[cfg(all(not(target_arch = "wasm32"), feature = "tokio-sleep"))]
 pub use sleep::TokioSleeper;
+#[cfg(all(not(feature="std"), feature = "embassy-sleep"))]
+pub use sleep::EmbassySleep;
 
 mod blocking_retry;
 pub use blocking_retry::{BlockingRetry, BlockingRetryable};

--- a/backon/src/retry.rs
+++ b/backon/src/retry.rs
@@ -319,7 +319,11 @@ where
 }
 
 #[cfg(test)]
-#[cfg(any(feature = "tokio-sleep", feature = "gloo-timers-sleep"))]
+#[cfg(any(
+    feature = "tokio-sleep",
+    feature = "gloo-timers-sleep",
+    feature = "embassy-time"
+))]
 mod default_sleeper_tests {
     use alloc::string::ToString;
     use alloc::vec;

--- a/backon/src/retry_with_context.rs
+++ b/backon/src/retry_with_context.rs
@@ -362,7 +362,11 @@ where
 }
 
 #[cfg(test)]
-#[cfg(any(feature = "tokio-sleep", feature = "gloo-timers-sleep"))]
+#[cfg(any(
+    feature = "tokio-sleep",
+    feature = "gloo-timers-sleep",
+    feature = "embassy-time"
+))]
 mod tests {
     use alloc::string::ToString;
     use anyhow::{anyhow, Result};

--- a/backon/src/sleep.rs
+++ b/backon/src/sleep.rs
@@ -36,7 +36,11 @@ impl<F: Fn(Duration) -> Fut + 'static, Fut: Future<Output = ()>> Sleeper for F {
 /// The default implementation of `Sleeper` when no features are enabled.
 ///
 /// It will fail to compile if a containing [`Retry`][crate::Retry] is `.await`ed without calling [`Retry::sleep`][crate::Retry::sleep] to provide a valid sleeper.
-#[cfg(all(not(feature = "tokio-sleep"), not(feature = "gloo-timers-sleep")))]
+#[cfg(all(
+    not(feature = "tokio-sleep"),
+    not(feature = "gloo-timers-sleep"),
+    not(feature = "embassy-sleep")
+))]
 pub type DefaultSleeper = PleaseEnableAFeatureOrProvideACustomSleeper;
 /// The default implementation of `Sleeper` while feature `tokio-sleep` enabled.
 ///
@@ -48,6 +52,11 @@ pub type DefaultSleeper = TokioSleeper;
 /// It uses `gloo_timers::sleep::sleep`.
 #[cfg(all(target_arch = "wasm32", feature = "gloo-timers-sleep"))]
 pub type DefaultSleeper = GlooTimersSleep;
+/// The default implementation of `Sleeper` while feature `embassy-sleep` enabled.
+///
+/// It uses `embassy_time::Timer`.
+#[cfg(all(not(feature = "std"), feature = "embassy-sleep"))]
+pub type DefaultSleeper = EmbassySleep;
 
 /// A placeholder type that does not implement [`Sleeper`] and will therefore fail to compile if used as one.
 ///
@@ -89,5 +98,19 @@ impl Sleeper for GlooTimersSleep {
 
     fn sleep(&self, dur: Duration) -> Self::Sleep {
         gloo_timers::future::sleep(dur)
+    }
+}
+
+/// The default implementation of `Sleeper` utilizes `embassy-time::Timer`.
+#[cfg(all(not(feature = "std"), feature = "embassy-sleep"))]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct EmbassySleep;
+
+#[cfg(all(not(feature = "std"), feature = "embassy-sleep"))]
+impl Sleeper for EmbassySleep {
+    type Sleep = embassy_time::Timer;
+
+    fn sleep(&self, dur: Duration) -> Self::Sleep {
+        embassy_time::Timer::after_millis(dur.as_millis() as u64)
     }
 }


### PR DESCRIPTION
I added a sleeper based on the embassy framework in no_std. Also did some adjustments to fastrand since the current no_std implementation did not compile. fastrand supports no_std, but only without a global RNG.