### PR TITLE
jitter: Make jitter range to current_delay instead of min_delay

### DIFF
--- a/backon/src/backoff/exponential.rs
+++ b/backon/src/backoff/exponential.rs
@@ -65,7 +65,7 @@ impl ExponentialBuilder {
 
     /// Enable jitter for the backoff.
     ///
-    /// When jitter is enabled, [`ExponentialBackoff`] will add a random jitter within `(0, min_delay)`
+    /// When jitter is enabled, [`ExponentialBackoff`] will add a random jitter within `(0, current_delay)`
     /// to the current delay.
     pub const fn with_jitter(mut self) -> Self {
         self.jitter = true;
@@ -216,7 +216,7 @@ impl Iterator for ExponentialBackoff {
         };
         // If jitter is enabled, add random jitter based on min delay.
         if self.jitter {
-            tmp_cur = tmp_cur.saturating_add(self.min_delay.mul_f32(self.rng.f32()));
+            tmp_cur = tmp_cur.saturating_add(tmp_cur.mul_f32(self.rng.f32()));
         }
         Some(tmp_cur)
     }

--- a/backon/src/backoff/fibonacci.rs
+++ b/backon/src/backoff/fibonacci.rs
@@ -62,7 +62,7 @@ impl FibonacciBuilder {
 
     /// Set the jitter for the backoff.
     ///
-    /// When jitter is enabled, FibonacciBackoff will add a random jitter between `(0, min_delay)` to the delay.
+    /// When jitter is enabled, FibonacciBackoff will add a random jitter between `(0, current_delay)` to the delay.
     pub const fn with_jitter(mut self) -> Self {
         self.jitter = true;
         self
@@ -187,7 +187,7 @@ impl Iterator for FibonacciBackoff {
 
                 // If jitter is enabled, add random jitter based on min delay.
                 if self.jitter {
-                    next += self.min_delay.mul_f32(self.rng.f32());
+                    next += next.mul_f32(self.rng.f32());
                 }
 
                 Some(next)


### PR DESCRIPTION
Currently in exponential and fibonacci the jitter adds a value between 0 and min_delay, which might be very small when compared to the end of the max_delay. So when reaching max_delay, and when many different endpoints use the backoff algorithm, they will hit the backends in waves

This changes it to range from 0 to current_delay, so the jitter is always a relevant size compared to the delays.

If you prefer this to be a different parameter, let me know an I will adjust.