### PR TITLE
Allow error-based override of the backoff sleep times

### DIFF
--- a/backon/src/docs/examples/inside_mut_self.md
+++ b/backon/src/docs/examples/inside_mut_self.md
@@ -15,7 +15,7 @@ Retry an async function inside `&mut self` functions.
      async fn run(&mut self) -> Result<String> {
          let content = (|| async { self.fetch("https://www.rust-lang.org").await })
              .retry(ExponentialBuilder::default())
-             .when(|e| e.to_string() == "retryable")
+             .when(|e| (e.to_string() == "retryable").into())
              .await?;
          Ok(content)
      }

--- a/backon/src/docs/examples/with_args.md
+++ b/backon/src/docs/examples/with_args.md
@@ -15,7 +15,7 @@ It's a pity that rust doesn't allow us to implement `Retryable` for async functi
  async fn main() -> Result<()> {
      let content = (|| async { fetch("https://www.rust-lang.org").await })
          .retry(ExponentialBuilder::default())
-         .when(|e| e.to_string() == "retryable")
+         .when(|e| (e.to_string() == "retryable").into())
          .await?;
 
      println!("fetch succeeded: {}", content);

--- a/backon/src/docs/examples/with_mut_self.md
+++ b/backon/src/docs/examples/with_mut_self.md
@@ -27,7 +27,7 @@ This is a bit more complex since we need to capture the receiver in the closure 
      .retry(ExponentialBuilder::default())
      // Passing context in.
      .context(test)
-     .when(|e| e.to_string() == "retryable")
+     .when(|e| (e.to_string() == "retryable").into())
      .await;
 
      println!("fetch succeeded: {}", result.unwrap());

--- a/backon/src/docs/examples/with_self.md
+++ b/backon/src/docs/examples/with_self.md
@@ -19,7 +19,7 @@ Retry an async function which takes `&self` as receiver.
      let test = Test;
      let content = (|| async { test.fetch("https://www.rust-lang.org").await })
          .retry(ExponentialBuilder::default())
-         .when(|e| e.to_string() == "retryable")
+         .when(|e| (e.to_string() == "retryable").into())
          .await?;
 
      println!("fetch succeeded: {}", content);

--- a/backon/src/docs/examples/with_specific_error.md
+++ b/backon/src/docs/examples/with_specific_error.md
@@ -13,7 +13,7 @@ async fn fetch() -> Result<String> {
 async fn main() -> Result<()> {
     let content = fetch
         .retry(ExponentialBuilder::default())
-        .when(|e| e.to_string() == "retryable")
+        .when(|e| (e.to_string() == "retryable").into())
         .await?;
     println!("fetch succeeded: {}", content);
     Ok(())

--- a/backon/src/retry_with_context.rs
+++ b/backon/src/retry_with_context.rs
@@ -212,7 +212,7 @@ where
     /// async fn main() -> Result<()> {
     ///     let content = fetch
     ///         .retry(ExponentialBuilder::default())
-    ///         .when(|e| e.to_string() == "EOF")
+    ///         .when(|e| (e.to_string() == "EOF").into())
     ///         .await?;
     ///     println!("fetch succeeded: {}", content);
     ///


### PR DESCRIPTION
This PR attempts to implement what is suggested in #63 and #150 in a more natural manner.

#63 implements support for overriding of the sleep time using a custom backoff algorithm. I think that any backoff algorithm might be used for cases where some sort of `Retry-After` header exists and as such I added support for this to the `Retry` future in the `when()` method.

I only implemented this for the async retry support, but the same mechanism can be ported to the blocking retry.

The one downside this approach has is that this is a breaking change, if that's not desirable we could introduce a new `when_with_override()` method which would implement this functionality while leaving the `when()` method as is.

Support for this is a prerequisite for us to migrate from the backoff crate to backon, as discussed in https://github.com/matrix-org/matrix-rust-sdk/issues/4243#issuecomment-2480668964.