### PR TITLE
Sleeper: drop constraint on Future's Output

### DIFF
--- a/backon/src/retry.rs
+++ b/backon/src/retry.rs
@@ -118,7 +118,7 @@ where
 {
     /// Set the sleeper for retrying.
     ///
-    /// The sleeper should implement the [`Sleeper`] trait. The simplest way is to use a closure that returns a `Future<Output=()>`.
+    /// The sleeper should implement the [`Sleeper`] trait. The simplest way is to use a closure that returns a `Future`.
     ///
     /// If not specified, we use the [`DefaultSleeper`].
     ///
@@ -344,7 +344,7 @@ where
 
 /// State maintains internal state of retry.
 #[derive(Default)]
-enum State<T, E, Fut: Future<Output = Result<T, E>>, SleepFut: Future<Output = ()>> {
+enum State<T, E, Fut: Future<Output = Result<T, E>>, SleepFut: Future> {
     #[default]
     Idle,
     Polling(Fut),

--- a/backon/src/retry_with_context.rs
+++ b/backon/src/retry_with_context.rs
@@ -151,7 +151,7 @@ where
 {
     /// Set the sleeper for retrying.
     ///
-    /// The sleeper should implement the [`Sleeper`] trait. The simplest way is to use a closure that returns a `Future<Output=()>`.
+    /// The sleeper should implement the [`Sleeper`] trait. The simplest way is to use a closure that returns a `Future`.
     ///
     /// If not specified, we use the [`DefaultSleeper`].
     pub fn sleep<SN: Sleeper>(
@@ -284,7 +284,7 @@ where
 }
 
 /// State maintains internal state of retry.
-enum State<T, E, Ctx, Fut: Future<Output = (Ctx, Result<T, E>)>, SleepFut: Future<Output = ()>> {
+enum State<T, E, Ctx, Fut: Future<Output = (Ctx, Result<T, E>)>, SleepFut: Future> {
     Idle(Option<Ctx>),
     Polling(Fut),
     Sleeping((Option<Ctx>, SleepFut)),

--- a/backon/src/sleep.rs
+++ b/backon/src/sleep.rs
@@ -5,7 +5,7 @@ use core::time::Duration;
 /// A sleeper is used to generate a future that completes after a specified duration.
 pub trait Sleeper: 'static {
     /// The future returned by the `sleep` method.
-    type Sleep: Future<Output = ()>;
+    type Sleep: Future;
 
     /// Create a future that completes after a set period.
     fn sleep(&self, dur: Duration) -> Self::Sleep;
@@ -15,7 +15,7 @@ pub trait Sleeper: 'static {
 /// It does not provide actual functionality.
 #[doc(hidden)]
 pub trait MaybeSleeper: 'static {
-    type Sleep: Future<Output = ()>;
+    type Sleep: Future;
 }
 
 /// All `Sleeper` will implement  `MaybeSleeper`, but not vice versa.
@@ -23,8 +23,8 @@ impl<T: Sleeper + ?Sized> MaybeSleeper for T {
     type Sleep = <T as Sleeper>::Sleep;
 }
 
-/// All `Fn(Duration) -> impl Future<Output = ()>` implements `Sleeper`.
-impl<F: Fn(Duration) -> Fut + 'static, Fut: Future<Output = ()>> Sleeper for F {
+/// All `Fn(Duration) -> impl Future` implements `Sleeper`.
+impl<F: Fn(Duration) -> Fut + 'static, Fut: Future> Sleeper for F {
     type Sleep = Fut;
 
     fn sleep(&self, dur: Duration) -> Self::Sleep {


### PR DESCRIPTION
We don't actually care what the sleeping returns, we just don't use this return value.
While some runtimes such as tokio chose to return (), others such as smol return the Instant at which the sleep ended.
Enforcing the output to () makes implementing Sleeper on e.g. smol more difficult that necessary as it forces the user to wrap e.g. smol::Timer into another future (such as futures::future::Map) instead of using the runtime types directly.