### PR TITLE
refactor: Bump edition to 2024 and MSRV to 1.85

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   # Minimum Supported Rust Version for backon
-  BACKON_MSRV: "1.70"
+  BACKON_MSRV: "1.85"
 
 jobs:
   check:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,6 @@ members = ["backon"]
 resolver = "2"
 
 [workspace.package]
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/Xuanwo/backon"

--- a/backon/Cargo.toml
+++ b/backon/Cargo.toml
@@ -3,7 +3,7 @@ description = "Make retry like a built-in feature provided by Rust."
 documentation = "https://docs.rs/backon"
 name = "backon"
 readme = "../README.md"
-rust-version = "1.70"
+rust-version = "1.85"
 version = "1.5.2"
 
 edition.workspace = true

--- a/backon/src/backoff/exponential.rs
+++ b/backon/src/backoff/exponential.rs
@@ -237,7 +237,7 @@ impl Iterator for ExponentialBackoff {
         // Check if adding the current delay would exceed the total delay limit.
         let total_delay_check = self
             .total_delay
-            .map_or(true, |total| self.cumulative_delay + tmp_cur <= total);
+            .is_none_or(|total| self.cumulative_delay + tmp_cur <= total);
 
         if !total_delay_check {
             return None;

--- a/backon/src/blocking_retry.rs
+++ b/backon/src/blocking_retry.rs
@@ -1,10 +1,10 @@
 use core::time::Duration;
 
-use crate::backoff::BackoffBuilder;
-use crate::blocking_sleep::MaybeBlockingSleeper;
 use crate::Backoff;
 use crate::BlockingSleeper;
 use crate::DefaultBlockingSleeper;
+use crate::backoff::BackoffBuilder;
+use crate::blocking_sleep::MaybeBlockingSleeper;
 
 /// BlockingRetryable adds retry support for blocking functions.
 ///

--- a/backon/src/blocking_retry_with_context.rs
+++ b/backon/src/blocking_retry_with_context.rs
@@ -1,10 +1,10 @@
 use core::time::Duration;
 
-use crate::backoff::BackoffBuilder;
-use crate::blocking_sleep::MaybeBlockingSleeper;
 use crate::Backoff;
 use crate::BlockingSleeper;
 use crate::DefaultBlockingSleeper;
+use crate::backoff::BackoffBuilder;
+use crate::blocking_sleep::MaybeBlockingSleeper;
 
 /// BlockingRetryableWithContext adds retry support for blocking functions.
 pub trait BlockingRetryableWithContext<
@@ -189,8 +189,8 @@ mod tests {
     use alloc::string::ToString;
     use core::time::Duration;
 
-    use anyhow::anyhow;
     use anyhow::Result;
+    use anyhow::anyhow;
     use spin::Mutex;
 
     use super::*;

--- a/backon/src/retry.rs
+++ b/backon/src/retry.rs
@@ -1,15 +1,15 @@
 use core::future::Future;
 use core::pin::Pin;
-use core::task::ready;
 use core::task::Context;
 use core::task::Poll;
+use core::task::ready;
 use core::time::Duration;
 
-use crate::backoff::BackoffBuilder;
-use crate::sleep::MaybeSleeper;
 use crate::Backoff;
 use crate::DefaultSleeper;
 use crate::Sleeper;
+use crate::backoff::BackoffBuilder;
+use crate::sleep::MaybeSleeper;
 
 /// Retryable will add retry support for functions that produce futures with results.
 ///

--- a/backon/src/retry_with_context.rs
+++ b/backon/src/retry_with_context.rs
@@ -1,15 +1,15 @@
 use core::future::Future;
 use core::pin::Pin;
-use core::task::ready;
 use core::task::Context;
 use core::task::Poll;
+use core::task::ready;
 use core::time::Duration;
 
-use crate::backoff::BackoffBuilder;
-use crate::sleep::MaybeSleeper;
 use crate::Backoff;
 use crate::DefaultSleeper;
 use crate::Sleeper;
+use crate::backoff::BackoffBuilder;
+use crate::sleep::MaybeSleeper;
 
 /// `RetryableWithContext` adds retry support for functions that produce futures with results
 /// and context.
@@ -369,8 +369,8 @@ mod tests {
     use alloc::string::ToString;
     use core::time::Duration;
 
-    use anyhow::anyhow;
     use anyhow::Result;
+    use anyhow::anyhow;
     use tokio::sync::Mutex;
     #[cfg(not(target_arch = "wasm32"))]
     use tokio::test;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,4 @@
-edition = "2021"
+edition = "2024"
 reorder_imports = true
 
 # format_code_in_doc_comments = true


### PR DESCRIPTION
This PR will bump backon's edition to 2024 and MSRV to 1.85 so that we can support more native features like https://github.com/Xuanwo/backon/pull/183

---

**This PR was primarily authored with Codex using GPT-5-Codex and then hand-reviewed by me. I AM responsible for every change made in this PR. I aimed to keep it aligned with our goals, though I may have missed minor issues. Please flag anything that feels off, I'll fix it quickly.**