### PR TITLE
refactor: Add RetryConfig to make code simple

### DIFF
--- a/backon/src/blocking_retry_with_context.rs
+++ b/backon/src/blocking_retry_with_context.rs
@@ -1,3 +1,4 @@
+use core::ops::ControlFlow;
 use core::time::Duration;
 
 use crate::Backoff;
@@ -5,6 +6,10 @@ use crate::BlockingSleeper;
 use crate::DefaultBlockingSleeper;
 use crate::backoff::BackoffBuilder;
 use crate::blocking_sleep::MaybeBlockingSleeper;
+use crate::retry_core::RetryConfig;
+use crate::retry_core::always_retry;
+use crate::retry_core::identity_adjust;
+use crate::retry_core::noop_notify;
 
 /// BlockingRetryableWithContext adds retry support for blocking functions.
 pub trait BlockingRetryableWithContext<
@@ -39,12 +44,10 @@ pub struct BlockingRetryWithContext<
     SF: MaybeBlockingSleeper = DefaultBlockingSleeper,
     RF = fn(&E) -> bool,
     NF = fn(&E, Duration),
+    AF = fn(&E, Option<Duration>) -> Option<Duration>,
 > {
-    backoff: B,
-    retryable: RF,
-    notify: NF,
+    config: RetryConfig<B, SF, RF, NF, AF>,
     f: F,
-    sleep_fn: SF,
     ctx: Option<Ctx>,
 }
 
@@ -56,34 +59,38 @@ where
     /// Create a new retry.
     fn new(f: F, backoff: B) -> Self {
         BlockingRetryWithContext {
-            backoff,
-            retryable: |_: &E| true,
-            notify: |_: &E, _: Duration| {},
-            sleep_fn: DefaultBlockingSleeper::default(),
+            config: RetryConfig::new(
+                backoff,
+                DefaultBlockingSleeper::default(),
+                always_retry::<E>,
+                noop_notify::<E>,
+                identity_adjust::<E>,
+            ),
             f,
             ctx: None,
         }
     }
 }
 
-impl<B, T, E, Ctx, F, SF, RF, NF> BlockingRetryWithContext<B, T, E, Ctx, F, SF, RF, NF>
+impl<B, T, E, Ctx, F, SF, RF, NF, AF> BlockingRetryWithContext<B, T, E, Ctx, F, SF, RF, NF, AF>
 where
     B: Backoff,
     F: FnMut(Ctx) -> (Ctx, Result<T, E>),
     SF: MaybeBlockingSleeper,
     RF: FnMut(&E) -> bool,
     NF: FnMut(&E, Duration),
+    AF: FnMut(&E, Option<Duration>) -> Option<Duration>,
 {
     /// Set the context for retrying.
     ///
     /// Context is used to capture ownership manually to prevent lifetime issues.
-    pub fn context(self, context: Ctx) -> BlockingRetryWithContext<B, T, E, Ctx, F, SF, RF, NF> {
+    pub fn context(
+        self,
+        context: Ctx,
+    ) -> BlockingRetryWithContext<B, T, E, Ctx, F, SF, RF, NF, AF> {
         BlockingRetryWithContext {
-            backoff: self.backoff,
-            retryable: self.retryable,
-            notify: self.notify,
+            config: self.config,
             f: self.f,
-            sleep_fn: self.sleep_fn,
             ctx: Some(context),
         }
     }
@@ -96,13 +103,10 @@ where
     pub fn sleep<SN: BlockingSleeper>(
         self,
         sleep_fn: SN,
-    ) -> BlockingRetryWithContext<B, T, E, Ctx, F, SN, RF, NF> {
+    ) -> BlockingRetryWithContext<B, T, E, Ctx, F, SN, RF, NF, AF> {
         BlockingRetryWithContext {
-            backoff: self.backoff,
-            retryable: self.retryable,
-            notify: self.notify,
+            config: self.config.with_sleep(sleep_fn),
             f: self.f,
-            sleep_fn,
             ctx: self.ctx,
         }
     }
@@ -113,13 +117,10 @@ where
     pub fn when<RN: FnMut(&E) -> bool>(
         self,
         retryable: RN,
-    ) -> BlockingRetryWithContext<B, T, E, Ctx, F, SF, RN, NF> {
+    ) -> BlockingRetryWithContext<B, T, E, Ctx, F, SF, RN, NF, AF> {
         BlockingRetryWithContext {
-            backoff: self.backoff,
-            retryable,
-            notify: self.notify,
+            config: self.config.with_retryable(retryable),
             f: self.f,
-            sleep_fn: self.sleep_fn,
             ctx: self.ctx,
         }
     }
@@ -132,25 +133,23 @@ where
     pub fn notify<NN: FnMut(&E, Duration)>(
         self,
         notify: NN,
-    ) -> BlockingRetryWithContext<B, T, E, Ctx, F, SF, RF, NN> {
+    ) -> BlockingRetryWithContext<B, T, E, Ctx, F, SF, RF, NN, AF> {
         BlockingRetryWithContext {
-            backoff: self.backoff,
-            retryable: self.retryable,
-            notify,
+            config: self.config.with_notify(notify),
             f: self.f,
-            sleep_fn: self.sleep_fn,
             ctx: self.ctx,
         }
     }
 }
 
-impl<B, T, E, Ctx, F, SF, RF, NF> BlockingRetryWithContext<B, T, E, Ctx, F, SF, RF, NF>
+impl<B, T, E, Ctx, F, SF, RF, NF, AF> BlockingRetryWithContext<B, T, E, Ctx, F, SF, RF, NF, AF>
 where
     B: Backoff,
     F: FnMut(Ctx) -> (Ctx, Result<T, E>),
     SF: BlockingSleeper,
     RF: FnMut(&E) -> bool,
     NF: FnMut(&E, Duration),
+    AF: FnMut(&E, Option<Duration>) -> Option<Duration>,
 {
     /// Call the retried function.
     ///
@@ -164,19 +163,12 @@ where
 
             match result {
                 Ok(v) => return (ctx, Ok(v)),
-                Err(err) => {
-                    if !(self.retryable)(&err) {
-                        return (ctx, Err(err));
+                Err(err) => match self.config.decide(&err) {
+                    ControlFlow::Continue(dur) => {
+                        self.config.sleep.sleep(dur);
                     }
-
-                    match self.backoff.next() {
-                        None => return (ctx, Err(err)),
-                        Some(dur) => {
-                            (self.notify)(&err, dur);
-                            self.sleep_fn.sleep(dur);
-                        }
-                    }
-                }
+                    ControlFlow::Break(_) => return (ctx, Err(err)),
+                },
             }
         }
     }

--- a/backon/src/lib.rs
+++ b/backon/src/lib.rs
@@ -221,6 +221,8 @@ mod retry;
 pub use retry::Retry;
 pub use retry::Retryable;
 
+mod retry_core;
+
 mod retry_with_context;
 pub use retry_with_context::RetryWithContext;
 pub use retry_with_context::RetryableWithContext;

--- a/backon/src/retry_core.rs
+++ b/backon/src/retry_core.rs
@@ -1,0 +1,109 @@
+use core::ops::ControlFlow;
+use core::time::Duration;
+
+use crate::Backoff;
+
+pub(crate) fn always_retry<E>(_: &E) -> bool {
+    true
+}
+
+pub(crate) fn noop_notify<E>(_: &E, _: Duration) {}
+
+pub(crate) fn identity_adjust<E>(_: &E, dur: Option<Duration>) -> Option<Duration> {
+    dur
+}
+
+/// Shared configuration for retry executors.
+pub(crate) struct RetryConfig<B, Sleep, RetryFn, NotifyFn, AdjustFn> {
+    pub(crate) backoff: B,
+    pub(crate) sleep: Sleep,
+    pub(crate) retryable: RetryFn,
+    pub(crate) notify: NotifyFn,
+    pub(crate) adjust: AdjustFn,
+}
+
+impl<B, Sleep, RetryFn, NotifyFn, AdjustFn> RetryConfig<B, Sleep, RetryFn, NotifyFn, AdjustFn> {
+    pub(crate) fn new(
+        backoff: B,
+        sleep: Sleep,
+        retryable: RetryFn,
+        notify: NotifyFn,
+        adjust: AdjustFn,
+    ) -> Self {
+        RetryConfig {
+            backoff,
+            sleep,
+            retryable,
+            notify,
+            adjust,
+        }
+    }
+
+    pub(crate) fn with_sleep<S>(self, sleep: S) -> RetryConfig<B, S, RetryFn, NotifyFn, AdjustFn> {
+        RetryConfig {
+            backoff: self.backoff,
+            sleep,
+            retryable: self.retryable,
+            notify: self.notify,
+            adjust: self.adjust,
+        }
+    }
+
+    pub(crate) fn with_retryable<R>(
+        self,
+        retryable: R,
+    ) -> RetryConfig<B, Sleep, R, NotifyFn, AdjustFn> {
+        RetryConfig {
+            backoff: self.backoff,
+            sleep: self.sleep,
+            retryable,
+            notify: self.notify,
+            adjust: self.adjust,
+        }
+    }
+
+    pub(crate) fn with_notify<N>(self, notify: N) -> RetryConfig<B, Sleep, RetryFn, N, AdjustFn> {
+        RetryConfig {
+            backoff: self.backoff,
+            sleep: self.sleep,
+            retryable: self.retryable,
+            notify,
+            adjust: self.adjust,
+        }
+    }
+
+    pub(crate) fn with_adjust<A>(self, adjust: A) -> RetryConfig<B, Sleep, RetryFn, NotifyFn, A> {
+        RetryConfig {
+            backoff: self.backoff,
+            sleep: self.sleep,
+            retryable: self.retryable,
+            notify: self.notify,
+            adjust,
+        }
+    }
+}
+
+impl<B, Sleep, RetryFn, NotifyFn, AdjustFn> RetryConfig<B, Sleep, RetryFn, NotifyFn, AdjustFn>
+where
+    B: Backoff,
+{
+    pub(crate) fn decide<E>(&mut self, err: &E) -> ControlFlow<(), Duration>
+    where
+        RetryFn: FnMut(&E) -> bool,
+        NotifyFn: FnMut(&E, Duration),
+        AdjustFn: FnMut(&E, Option<Duration>) -> Option<Duration>,
+    {
+        if !(self.retryable)(err) {
+            return ControlFlow::Break(());
+        }
+
+        let candidate = self.backoff.next();
+        match (self.adjust)(err, candidate) {
+            Some(dur) => {
+                (self.notify)(err, dur);
+                ControlFlow::Continue(dur)
+            }
+            None => ControlFlow::Break(()),
+        }
+    }
+}


### PR DESCRIPTION
This PR adds `RetryConfig` to make it's easier to maintain the retry behavior logic.

---

**This PR was primarily authored with Codex using GPT-5-Codex and then hand-reviewed by me. I AM responsible for every change made in this PR. I aimed to keep it aligned with our goals, though I may have missed minor issues. Please flag anything that feels off, I'll fix it quickly.**