### PR TITLE
Fix a compilation error if only std-blocking-sleep was enabled

### DIFF
--- a/backon/Cargo.toml
+++ b/backon/Cargo.toml
@@ -25,7 +25,7 @@ embassy-sleep = ["embassy-time"]
 futures-timer-sleep = ["futures-timer"]
 gloo-timers-sleep = ["gloo-timers/futures"]
 std = ["fastrand/std"]
-std-blocking-sleep = []
+std-blocking-sleep = ["fastrand/std"]
 tokio-sleep = ["tokio/time"]
 
 [dependencies]


### PR DESCRIPTION
The error:

```
$ cargo test --no-default-features --features std-blocking-sleep
   Compiling backon v1.6.0 (/home/capitol/project/backon/backon)
error[E0425]: cannot find function `seed` in crate `fastrand`
   --> backon/src/backoff/constant.rs:214:19
    |
214 |         fastrand::seed(7);
    |                   ^^^^ not found in `fastrand`

For more information about this error, try `rustc --explain E0425`.
error: could not compile `backon` (lib test) due to 1 previous error
```

from: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/backon/debian/patches/fix-std-blocking-sleep.patch