### PR TITLE
Fix exponential backoff max delay

### DIFF
--- a/backon-macros/src/lib.rs
+++ b/backon-macros/src/lib.rs
@@ -97,7 +97,7 @@ fn expand_backon(args: TokenStream, input: TokenStream) -> syn::Result<TokenStre
         let original_block = (*item_fn.block).clone();
         let body_tokens = quote!(#original_block);
         let block = build_function_body(&args, &item_fn.sig, body_tokens, None, false, false)?;
-        item_fn.block = Box::new(block);
+        *item_fn.block = block;
         return Ok(TokenStream::from(quote!(#item_fn)));
     }
 

--- a/backon-macros/tests/cases/fail_adjust_blocking.stderr
+++ b/backon-macros/tests/cases/fail_adjust_blocking.stderr
@@ -3,9 +3,3 @@ error: `adjust` is only available for async functions
   |
 8 | fn invalid_blocking() -> Result<(), &'static str> {
   |    ^^^^^^^^^^^^^^^^
-
-error[E0425]: cannot find function `invalid_blocking` in this scope
-  --> tests/cases/fail_adjust_blocking.rs:13:13
-   |
-13 |     let _ = invalid_blocking();
-   |             ^^^^^^^^^^^^^^^^ not found in this scope

--- a/backon/src/backoff/exponential.rs
+++ b/backon/src/backoff/exponential.rs
@@ -209,8 +209,11 @@ impl Iterator for ExponentialBackoff {
 
         let mut tmp_cur = match self.current_delay {
             None => {
-                // If current_delay is None, it's must be the first time to retry.
-                self.min_delay
+                // If current_delay is None, this is the first retry.
+                // Start from min_delay, but respect max_delay if configured.
+                self.max_delay
+                    .min(Some(self.min_delay))
+                    .unwrap_or(self.min_delay)
             }
             Some(mut cur) => {
                 // If current delay larger than max delay, we should stop increment anymore.
@@ -233,6 +236,10 @@ impl Iterator for ExponentialBackoff {
         if self.jitter {
             tmp_cur = tmp_cur.saturating_add(tmp_cur.mul_f32(self.rng.f32()));
         }
+
+        // Clamp the computed delay to max_delay if one is configured.
+        // It's important to not exceed max delay.
+        tmp_cur = self.max_delay.min(Some(tmp_cur)).unwrap_or(tmp_cur);
 
         // Check if adding the current delay would exceed the total delay limit.
         let total_delay_check = self
@@ -445,6 +452,50 @@ mod tests {
         let mut exp = ExponentialBuilder::default().with_max_times(1).build();
 
         assert_eq!(Some(Duration::from_secs(1)), exp.next());
+        assert_eq!(None, exp.next());
+    }
+
+    #[test]
+    fn test_exponential_exceeds_max_delay() {
+        const MAX_DELAY: Duration = Duration::from_millis(600);
+
+        let mut exp = ExponentialBuilder::new()
+            .with_max_times(2)
+            .with_jitter()
+            .with_max_delay(MAX_DELAY)
+            .build();
+
+        assert_eq!(
+            Some(MAX_DELAY),
+            exp.next(),
+            "Max delay should be greater than or equal to the next wait time",
+        );
+        assert_eq!(
+            Some(MAX_DELAY),
+            exp.next(),
+            "Max delay should be greater than or equal to the next wait time"
+        );
+        assert_eq!(None, exp.next());
+    }
+
+    #[test]
+    fn test_exponential_min_delay_larger_than_max() {
+        const MAX_DELAY: Duration = Duration::from_millis(500);
+        const MIN_DELAY: Duration = Duration::from_secs(5);
+
+        let mut exp = ExponentialBuilder::new()
+            .with_max_times(2)
+            .with_jitter()
+            .with_max_delay(MAX_DELAY)
+            .with_min_delay(MIN_DELAY)
+            .build();
+
+        assert_eq!(
+            Some(MAX_DELAY),
+            exp.next(),
+            "Max delay should be greater than or equal to the next wait time"
+        );
+        assert_eq!(Some(MAX_DELAY), exp.next());
         assert_eq!(None, exp.next());
     }
 


### PR DESCRIPTION
This PR fixes a critical bug in the exponential backoff implementation where the `max_delay` parameter was not being properly respected during retry calculations. The fix ensures that the computed backoff delay never exceeds the configured maximum, and addresses an edge case where `min_delay` is larger than `max_delay`. 