### PR TITLE
feat: add maximum elapsed time to retries

### DIFF
--- a/backon-macros/src/lib.rs
+++ b/backon-macros/src/lib.rs
@@ -97,7 +97,7 @@ fn expand_backon(args: TokenStream, input: TokenStream) -> syn::Result<TokenStre
         let original_block = (*item_fn.block).clone();
         let body_tokens = quote!(#original_block);
         let block = build_function_body(&args, &item_fn.sig, body_tokens, None, false, false)?;
-        item_fn.block = Box::new(block);
+        *item_fn.block = block;
         return Ok(TokenStream::from(quote!(#item_fn)));
     }
 

--- a/backon-macros/tests/cases/fail_adjust_blocking.stderr
+++ b/backon-macros/tests/cases/fail_adjust_blocking.stderr
@@ -3,9 +3,3 @@ error: `adjust` is only available for async functions
   |
 8 | fn invalid_blocking() -> Result<(), &'static str> {
   |    ^^^^^^^^^^^^^^^^
-
-error[E0425]: cannot find function `invalid_blocking` in this scope
-  --> tests/cases/fail_adjust_blocking.rs:13:13
-   |
-13 |     let _ = invalid_blocking();
-   |             ^^^^^^^^^^^^^^^^ not found in this scope

--- a/backon/Cargo.toml
+++ b/backon/Cargo.toml
@@ -24,7 +24,7 @@ default = ["std", "std-blocking-sleep", "tokio-sleep", "gloo-timers-sleep"]
 embassy-sleep = ["embassy-time"]
 futures-timer-sleep = ["futures-timer"]
 gloo-timers-sleep = ["gloo-timers/futures"]
-std = ["fastrand/std"]
+std = ["fastrand/std", "dep:web-time"]
 std-blocking-sleep = []
 tokio-sleep = ["tokio/time"]
 
@@ -41,6 +41,9 @@ futures-timer = { version = "3.0.3", optional = true, features = [
   "gloo-timers",
 ] }
 gloo-timers = { version = "0.3", optional = true }
+
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+web-time = { version = "1", optional = true }
 
 [dev-dependencies]
 anyhow = "1"

--- a/backon/src/blocking_retry.rs
+++ b/backon/src/blocking_retry.rs
@@ -108,6 +108,19 @@ where
     NF: FnMut(&E, Duration),
     AF: FnMut(&E, Option<Duration>) -> Option<Duration>,
 {
+    /// Set the maximum elapsed time for retry attempts.
+    ///
+    /// Pass `None` to leave the elapsed time unbounded.
+    ///
+    /// The timer starts when [`Self::call`] begins. Once the elapsed time reaches this limit, BackON
+    /// returns the latest error instead of scheduling another retry. It does not interrupt an attempt
+    /// or sleep that is already in progress.
+    #[cfg(feature = "std")]
+    pub fn with_max_elapsed_time(mut self, max_elapsed_time: impl Into<Option<Duration>>) -> Self {
+        self.config = self.config.with_max_elapsed_time(max_elapsed_time.into());
+        self
+    }
+
     /// Set the sleeper for retrying.
     ///
     /// The sleeper should implement the [`BlockingSleeper`] trait. The simplest way is to use a closure like  `Fn(Duration)`.
@@ -235,6 +248,7 @@ where
     ///
     /// TODO: implement [`FnOnce`] after it stable.
     pub fn call(mut self) -> Result<T, E> {
+        self.config.start();
         loop {
             let result = (self.f)();
 
@@ -277,6 +291,23 @@ mod tests {
         assert!(result.is_err());
         assert_eq!("test_query meets error", result.unwrap_err().to_string());
         Ok(())
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn max_elapsed_time_zero_should_not_retry() {
+        let attempts = Mutex::new(0);
+
+        let result = (|| {
+            *attempts.lock() += 1;
+            Err::<(), _>(anyhow::anyhow!("retryable"))
+        })
+        .retry(ExponentialBuilder::default())
+        .with_max_elapsed_time(Duration::ZERO)
+        .call();
+
+        assert!(result.is_err());
+        assert_eq!(*attempts.lock(), 1);
     }
 
     #[test]

--- a/backon/src/blocking_retry.rs
+++ b/backon/src/blocking_retry.rs
@@ -295,7 +295,7 @@ mod tests {
 
     #[cfg(feature = "std")]
     #[test]
-    fn max_elapsed_time_zero_should_not_retry() {
+    fn test_max_elapsed_time() {
         let attempts = Mutex::new(0);
 
         let result = (|| {

--- a/backon/src/blocking_retry_with_context.rs
+++ b/backon/src/blocking_retry_with_context.rs
@@ -212,7 +212,7 @@ mod tests {
 
     #[cfg(feature = "std")]
     #[test]
-    fn max_elapsed_time_zero_should_return_context_without_retrying() {
+    fn test_max_elapsed_time() {
         let attempts = Mutex::new(0);
 
         let (_ctx, result) = (|ctx| {

--- a/backon/src/blocking_retry_with_context.rs
+++ b/backon/src/blocking_retry_with_context.rs
@@ -81,6 +81,19 @@ where
     NF: FnMut(&E, Duration),
     AF: FnMut(&E, Option<Duration>) -> Option<Duration>,
 {
+    /// Set the maximum elapsed time for retry attempts.
+    ///
+    /// Pass `None` to leave the elapsed time unbounded.
+    ///
+    /// The timer starts when [`Self::call`] begins. Once the elapsed time reaches this limit, BackON
+    /// returns the latest error and context instead of scheduling another retry. It does not interrupt
+    /// an attempt or sleep that is already in progress.
+    #[cfg(feature = "std")]
+    pub fn with_max_elapsed_time(mut self, max_elapsed_time: impl Into<Option<Duration>>) -> Self {
+        self.config = self.config.with_max_elapsed_time(max_elapsed_time.into());
+        self
+    }
+
     /// Set the context for retrying.
     ///
     /// Context is used to capture ownership manually to prevent lifetime issues.
@@ -155,6 +168,7 @@ where
     ///
     /// TODO: implement [`FnOnce`] after it stable.
     pub fn call(mut self) -> (Ctx, Result<T, E>) {
+        self.config.start();
         let mut ctx = self.ctx.take().expect("context must be valid");
         loop {
             let (xctx, result) = (self.f)(ctx);
@@ -194,6 +208,24 @@ mod tests {
         fn hello(&mut self) -> Result<usize> {
             Err(anyhow!("not retryable"))
         }
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn max_elapsed_time_zero_should_return_context_without_retrying() {
+        let attempts = Mutex::new(0);
+
+        let (_ctx, result) = (|ctx| {
+            *attempts.lock() += 1;
+            (ctx, Err::<(), _>(anyhow!("retryable")))
+        })
+        .retry(ExponentialBuilder::default())
+        .with_max_elapsed_time(Duration::ZERO)
+        .context(Test)
+        .call();
+
+        assert!(result.is_err());
+        assert_eq!(*attempts.lock(), 1);
     }
 
     #[test]

--- a/backon/src/lib.rs
+++ b/backon/src/lib.rs
@@ -211,7 +211,7 @@
 #![deny(unused_qualifications)]
 #![no_std]
 
-#[cfg(feature = "std-blocking-sleep")]
+#[cfg(any(feature = "std", feature = "std-blocking-sleep"))]
 extern crate std;
 
 mod backoff;

--- a/backon/src/retry.rs
+++ b/backon/src/retry.rs
@@ -414,10 +414,10 @@ where
 mod default_sleeper_tests {
     extern crate alloc;
 
+    use alloc::boxed::Box;
     use alloc::string::ToString;
     use alloc::vec;
     use alloc::vec::Vec;
-    #[cfg(not(target_arch = "wasm32"))]
     use core::future::ready;
     use core::time::Duration;
 
@@ -428,7 +428,6 @@ mod default_sleeper_tests {
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
     use super::*;
-    #[cfg(not(target_arch = "wasm32"))]
     use crate::ConstantBuilder;
     use crate::ExponentialBuilder;
 
@@ -448,7 +447,7 @@ mod default_sleeper_tests {
 
     #[cfg(feature = "std")]
     #[test]
-    async fn max_elapsed_time_zero_should_not_retry() {
+    async fn test_max_elapsed_time() {
         let attempts = Mutex::new(0);
 
         let result = (|| async {
@@ -463,26 +462,29 @@ mod default_sleeper_tests {
         assert_eq!(*attempts.lock().await, 1);
     }
 
-    #[cfg(all(feature = "std", not(target_arch = "wasm32")))]
+    #[cfg(feature = "std")]
     #[test]
-    async fn max_elapsed_time_should_start_when_first_attempt_begins() {
+    async fn test_max_elapsed_time_starts_on_poll() {
         let attempts = Mutex::new(0);
-        let retry = (|| async {
-            *attempts.lock().await += 1;
-            Err::<(), _>(anyhow::anyhow!("retryable"))
-        })
-        .retry(
-            ConstantBuilder::default()
-                .with_delay(Duration::ZERO)
-                .with_max_times(1),
-        )
-        .with_max_elapsed_time(Duration::from_millis(1))
-        .sleep(|_| ready(()));
+        let mut retry = Box::pin(
+            (|| async {
+                *attempts.lock().await += 1;
+                Err::<(), _>(anyhow::anyhow!("retryable"))
+            })
+            .retry(
+                ConstantBuilder::default()
+                    .with_delay(Duration::ZERO)
+                    .with_max_times(1),
+            )
+            .with_max_elapsed_time(Duration::from_secs(60))
+            .sleep(|_| ready(())),
+        );
 
-        tokio::time::sleep(Duration::from_millis(10)).await;
-        let result = retry.await;
+        assert!(!retry.as_ref().get_ref().config.timer_started());
+        let result = retry.as_mut().await;
 
         assert!(result.is_err());
+        assert!(retry.as_ref().get_ref().config.timer_started());
         assert_eq!(*attempts.lock().await, 2);
     }
 

--- a/backon/src/retry.rs
+++ b/backon/src/retry.rs
@@ -115,6 +115,19 @@ where
     NF: FnMut(&E, Duration),
     AF: FnMut(&E, Option<Duration>) -> Option<Duration>,
 {
+    /// Set the maximum elapsed time for retry attempts.
+    ///
+    /// Pass `None` to leave the elapsed time unbounded.
+    ///
+    /// The timer starts when the first attempt begins. Once the elapsed time reaches this limit,
+    /// BackON returns the latest error instead of scheduling another retry. It does not interrupt an
+    /// attempt or sleep that is already in progress.
+    #[cfg(feature = "std")]
+    pub fn with_max_elapsed_time(mut self, max_elapsed_time: impl Into<Option<Duration>>) -> Self {
+        self.config = self.config.with_max_elapsed_time(max_elapsed_time.into());
+        self
+    }
+
     /// Set the sleeper for retrying.
     ///
     /// The sleeper should implement the [`Sleeper`] trait. The simplest way is to use a closure that returns a `Future`.
@@ -357,6 +370,7 @@ where
         loop {
             match &mut this.state {
                 State::Idle => {
+                    this.config.start();
                     let fut = (this.future_fn)();
                     this.state = State::Polling(fut);
                     continue;
@@ -403,6 +417,8 @@ mod default_sleeper_tests {
     use alloc::string::ToString;
     use alloc::vec;
     use alloc::vec::Vec;
+    #[cfg(not(target_arch = "wasm32"))]
+    use core::future::ready;
     use core::time::Duration;
 
     use tokio::sync::Mutex;
@@ -412,6 +428,8 @@ mod default_sleeper_tests {
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
     use super::*;
+    #[cfg(not(target_arch = "wasm32"))]
+    use crate::ConstantBuilder;
     use crate::ExponentialBuilder;
 
     async fn always_error() -> anyhow::Result<()> {
@@ -426,6 +444,46 @@ mod default_sleeper_tests {
 
         assert!(result.is_err());
         assert_eq!("test_query meets error", result.unwrap_err().to_string());
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    async fn max_elapsed_time_zero_should_not_retry() {
+        let attempts = Mutex::new(0);
+
+        let result = (|| async {
+            *attempts.lock().await += 1;
+            Err::<(), _>(anyhow::anyhow!("retryable"))
+        })
+        .retry(ExponentialBuilder::default())
+        .with_max_elapsed_time(Duration::ZERO)
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(*attempts.lock().await, 1);
+    }
+
+    #[cfg(all(feature = "std", not(target_arch = "wasm32")))]
+    #[test]
+    async fn max_elapsed_time_should_start_when_first_attempt_begins() {
+        let attempts = Mutex::new(0);
+        let retry = (|| async {
+            *attempts.lock().await += 1;
+            Err::<(), _>(anyhow::anyhow!("retryable"))
+        })
+        .retry(
+            ConstantBuilder::default()
+                .with_delay(Duration::ZERO)
+                .with_max_times(1),
+        )
+        .with_max_elapsed_time(Duration::from_millis(1))
+        .sleep(|_| ready(()));
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let result = retry.await;
+
+        assert!(result.is_err());
+        assert_eq!(*attempts.lock().await, 2);
     }
 
     #[test]

--- a/backon/src/retry_core.rs
+++ b/backon/src/retry_core.rs
@@ -175,6 +175,8 @@ mod tests {
     use crate::BackoffBuilder;
     #[cfg(feature = "std")]
     use crate::ConstantBuilder;
+    #[cfg(all(feature = "std", target_arch = "wasm32"))]
+    use wasm_bindgen_test::wasm_bindgen_test as test;
 
     #[cfg(feature = "std")]
     #[test]

--- a/backon/src/retry_core.rs
+++ b/backon/src/retry_core.rs
@@ -117,6 +117,11 @@ impl<B, Sleep, RetryFn, NotifyFn, AdjustFn> RetryConfig<B, Sleep, RetryFn, Notif
         }
     }
 
+    #[cfg(all(test, feature = "std"))]
+    pub(crate) fn timer_started(&self) -> bool {
+        self.timer.started_at.is_some()
+    }
+
     fn has_elapsed(&self) -> bool {
         #[cfg(feature = "std")]
         {
@@ -169,7 +174,7 @@ mod tests {
     use crate::ConstantBuilder;
 
     #[test]
-    fn elapsed_limit_should_stop_before_consuming_backoff() {
+    fn test_elapsed_limit_before_backoff() {
         let backoff = ConstantBuilder::default()
             .with_delay(Duration::from_secs(1))
             .with_max_times(1)
@@ -181,13 +186,12 @@ mod tests {
             noop_notify::<()>,
             identity_adjust::<()>,
         )
-        .with_max_elapsed_time(Some(Duration::from_secs(1)));
+        .with_max_elapsed_time(Some(Duration::ZERO));
         config.start();
-        config.timer.started_at = Some(Instant::now() - Duration::from_secs(2));
 
         assert_eq!(config.decide(&()), ControlFlow::Break(()));
 
-        config.timer.started_at = Some(Instant::now());
+        config.timer.max_elapsed_time = Some(Duration::MAX);
         assert_eq!(
             config.decide(&()),
             ControlFlow::Continue(Duration::from_secs(1))
@@ -195,9 +199,9 @@ mod tests {
     }
 
     #[test]
-    fn elapsed_limit_should_allow_sleep_that_crosses_limit() {
+    fn test_elapsed_limit_with_longer_delay() {
         let backoff = ConstantBuilder::default()
-            .with_delay(Duration::from_secs(1))
+            .with_delay(Duration::from_secs(2 * 60 * 60))
             .with_max_times(1)
             .build();
         let mut config = RetryConfig::new(
@@ -207,13 +211,12 @@ mod tests {
             noop_notify::<()>,
             identity_adjust::<()>,
         )
-        .with_max_elapsed_time(Some(Duration::from_millis(10)));
+        .with_max_elapsed_time(Some(Duration::from_secs(60 * 60)));
         config.start();
-        config.timer.started_at = Some(Instant::now() - Duration::from_millis(1));
 
         assert_eq!(
             config.decide(&()),
-            ControlFlow::Continue(Duration::from_secs(1))
+            ControlFlow::Continue(Duration::from_secs(2 * 60 * 60))
         );
     }
 }

--- a/backon/src/retry_core.rs
+++ b/backon/src/retry_core.rs
@@ -1,6 +1,14 @@
 use core::ops::ControlFlow;
 use core::time::Duration;
 
+#[cfg(all(
+    feature = "std",
+    not(all(target_arch = "wasm32", target_os = "unknown"))
+))]
+use std::time::Instant;
+#[cfg(all(feature = "std", target_arch = "wasm32", target_os = "unknown"))]
+use web_time::Instant;
+
 use crate::Backoff;
 
 pub(crate) fn always_retry<E>(_: &E) -> bool {
@@ -20,6 +28,15 @@ pub(crate) struct RetryConfig<B, Sleep, RetryFn, NotifyFn, AdjustFn> {
     pub(crate) retryable: RetryFn,
     pub(crate) notify: NotifyFn,
     pub(crate) adjust: AdjustFn,
+    timer: RetryTimer,
+}
+
+#[derive(Default)]
+struct RetryTimer {
+    #[cfg(feature = "std")]
+    max_elapsed_time: Option<Duration>,
+    #[cfg(feature = "std")]
+    started_at: Option<Instant>,
 }
 
 impl<B, Sleep, RetryFn, NotifyFn, AdjustFn> RetryConfig<B, Sleep, RetryFn, NotifyFn, AdjustFn> {
@@ -36,6 +53,7 @@ impl<B, Sleep, RetryFn, NotifyFn, AdjustFn> RetryConfig<B, Sleep, RetryFn, Notif
             retryable,
             notify,
             adjust,
+            timer: RetryTimer::default(),
         }
     }
 
@@ -46,6 +64,7 @@ impl<B, Sleep, RetryFn, NotifyFn, AdjustFn> RetryConfig<B, Sleep, RetryFn, Notif
             retryable: self.retryable,
             notify: self.notify,
             adjust: self.adjust,
+            timer: self.timer,
         }
     }
 
@@ -59,6 +78,7 @@ impl<B, Sleep, RetryFn, NotifyFn, AdjustFn> RetryConfig<B, Sleep, RetryFn, Notif
             retryable,
             notify: self.notify,
             adjust: self.adjust,
+            timer: self.timer,
         }
     }
 
@@ -69,6 +89,7 @@ impl<B, Sleep, RetryFn, NotifyFn, AdjustFn> RetryConfig<B, Sleep, RetryFn, Notif
             retryable: self.retryable,
             notify,
             adjust: self.adjust,
+            timer: self.timer,
         }
     }
 
@@ -79,7 +100,36 @@ impl<B, Sleep, RetryFn, NotifyFn, AdjustFn> RetryConfig<B, Sleep, RetryFn, Notif
             retryable: self.retryable,
             notify: self.notify,
             adjust,
+            timer: self.timer,
         }
+    }
+
+    #[cfg(feature = "std")]
+    pub(crate) fn with_max_elapsed_time(mut self, max_elapsed_time: Option<Duration>) -> Self {
+        self.timer.max_elapsed_time = max_elapsed_time;
+        self
+    }
+
+    pub(crate) fn start(&mut self) {
+        #[cfg(feature = "std")]
+        if self.timer.max_elapsed_time.is_some() && self.timer.started_at.is_none() {
+            self.timer.started_at = Some(Instant::now());
+        }
+    }
+
+    fn has_elapsed(&self) -> bool {
+        #[cfg(feature = "std")]
+        {
+            self.timer
+                .max_elapsed_time
+                .zip(self.timer.started_at)
+                .is_some_and(|(max_elapsed_time, started_at)| {
+                    started_at.elapsed() >= max_elapsed_time
+                })
+        }
+
+        #[cfg(not(feature = "std"))]
+        false
     }
 }
 
@@ -97,6 +147,10 @@ where
             return ControlFlow::Break(());
         }
 
+        if self.has_elapsed() {
+            return ControlFlow::Break(());
+        }
+
         let candidate = self.backoff.next();
         match (self.adjust)(err, candidate) {
             Some(dur) => {
@@ -105,5 +159,61 @@ where
             }
             None => ControlFlow::Break(()),
         }
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+    use crate::BackoffBuilder;
+    use crate::ConstantBuilder;
+
+    #[test]
+    fn elapsed_limit_should_stop_before_consuming_backoff() {
+        let backoff = ConstantBuilder::default()
+            .with_delay(Duration::from_secs(1))
+            .with_max_times(1)
+            .build();
+        let mut config = RetryConfig::new(
+            backoff,
+            (),
+            always_retry::<()>,
+            noop_notify::<()>,
+            identity_adjust::<()>,
+        )
+        .with_max_elapsed_time(Some(Duration::from_secs(1)));
+        config.start();
+        config.timer.started_at = Some(Instant::now() - Duration::from_secs(2));
+
+        assert_eq!(config.decide(&()), ControlFlow::Break(()));
+
+        config.timer.started_at = Some(Instant::now());
+        assert_eq!(
+            config.decide(&()),
+            ControlFlow::Continue(Duration::from_secs(1))
+        );
+    }
+
+    #[test]
+    fn elapsed_limit_should_allow_sleep_that_crosses_limit() {
+        let backoff = ConstantBuilder::default()
+            .with_delay(Duration::from_secs(1))
+            .with_max_times(1)
+            .build();
+        let mut config = RetryConfig::new(
+            backoff,
+            (),
+            always_retry::<()>,
+            noop_notify::<()>,
+            identity_adjust::<()>,
+        )
+        .with_max_elapsed_time(Some(Duration::from_millis(10)));
+        config.start();
+        config.timer.started_at = Some(Instant::now() - Duration::from_millis(1));
+
+        assert_eq!(
+            config.decide(&()),
+            ControlFlow::Continue(Duration::from_secs(1))
+        );
     }
 }

--- a/backon/src/retry_core.rs
+++ b/backon/src/retry_core.rs
@@ -167,12 +167,16 @@ where
     }
 }
 
-#[cfg(all(test, feature = "std"))]
+#[cfg(test)]
 mod tests {
+    #[cfg(feature = "std")]
     use super::*;
+    #[cfg(feature = "std")]
     use crate::BackoffBuilder;
+    #[cfg(feature = "std")]
     use crate::ConstantBuilder;
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_elapsed_limit_before_backoff() {
         let backoff = ConstantBuilder::default()
@@ -198,6 +202,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_elapsed_limit_with_longer_delay() {
         let backoff = ConstantBuilder::default()

--- a/backon/src/retry_with_context.rs
+++ b/backon/src/retry_with_context.rs
@@ -155,6 +155,19 @@ where
     NF: FnMut(&E, Duration),
     AF: FnMut(&E, Option<Duration>) -> Option<Duration>,
 {
+    /// Set the maximum elapsed time for retry attempts.
+    ///
+    /// Pass `None` to leave the elapsed time unbounded.
+    ///
+    /// The timer starts when the first attempt begins. Once the elapsed time reaches this limit,
+    /// BackON returns the latest error and context instead of scheduling another retry. It does not
+    /// interrupt an attempt or sleep that is already in progress.
+    #[cfg(feature = "std")]
+    pub fn with_max_elapsed_time(mut self, max_elapsed_time: impl Into<Option<Duration>>) -> Self {
+        self.config = self.config.with_max_elapsed_time(max_elapsed_time.into());
+        self
+    }
+
     /// Set the sleeper for retrying.
     ///
     /// The sleeper should implement the [`Sleeper`] trait. The simplest way is to use a closure that returns a `Future`.
@@ -307,6 +320,7 @@ where
         loop {
             match &mut this.state {
                 State::Idle(ctx) => {
+                    this.config.start();
                     let ctx = ctx.take().expect("context must be valid");
                     let fut = (this.future_fn)(ctx);
                     this.state = State::Polling(fut);
@@ -374,6 +388,24 @@ mod tests {
         async fn hello(&mut self) -> Result<usize> {
             Err(anyhow!("not retryable"))
         }
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    async fn max_elapsed_time_zero_should_return_context_without_retrying() {
+        let attempts = Mutex::new(0);
+
+        let (_ctx, result) = (|ctx| async {
+            *attempts.lock().await += 1;
+            (ctx, Err::<(), _>(anyhow!("retryable")))
+        })
+        .retry(ExponentialBuilder::default())
+        .with_max_elapsed_time(Duration::ZERO)
+        .context(Test)
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(*attempts.lock().await, 1);
     }
 
     #[test]

--- a/backon/src/retry_with_context.rs
+++ b/backon/src/retry_with_context.rs
@@ -392,7 +392,7 @@ mod tests {
 
     #[cfg(feature = "std")]
     #[test]
-    async fn max_elapsed_time_zero_should_return_context_without_retrying() {
+    async fn test_max_elapsed_time() {
         let attempts = Mutex::new(0);
 
         let (_ctx, result) = (|ctx| async {


### PR DESCRIPTION
## Summary

- add an executor-level maximum elapsed time across async, blocking, and context-aware retries
- start timing with the first attempt and stop before scheduling a new retry without interrupting admitted work
- use std::time::Instant on native targets and web-time only on browser WASM while preserving no_std builds

This enables OpenDAL to implement apache/opendal#8110 without duplicating retry timing across its stateful operations.
